### PR TITLE
Modification : désactivation de prometheus (Mantis 41978)

### DIFF
--- a/gitlab/forge-gitlab.nomad.tpl
+++ b/gitlab/forge-gitlab.nomad.tpl
@@ -103,6 +103,7 @@ main:
   allow_username_or_email_login: false
   lowercase_usernames: false
 EOS
+prometheus['enable'] = false
                 EOH
             }
 


### PR DESCRIPTION
Désactivation de prometheus sur Gitlab, afin de limiter l'utilisation de l'espace de stockage. Prometheus est très consommateur et n'est pour le moment pas utilisé (Mantis 41978).