### PR TITLE
Fix/version images fixes - sur la branche de prod

### DIFF
--- a/gitlab-runner-java_backup.sh
+++ b/gitlab-runner-java_backup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+echo "Démarrage du script de sauvegarde de gitlab-runner-java"
+#############################################################################
+# Nom du script     : gitlab-runner-java-backup.sh
+# Auteur            : S.IBN CHARRADA (QM HENIX)
+# Date de Création  : 31/05/2023
+# Version           : 0.0.1
+# Descritpion       : Script permettant la sauvegarde des données (configuration) de Gitlab
+#
+# Historique des mises à jour :
+#-----------+--------+-------------+------------------------------------------------------
+#  Version  |   Date   |   Auteur     |  Description
+#-----------+--------+-------------+------------------------------------------------------
+#  0.0.1    | 31/05/23 | S.IBN CHARRADA    | Initialisation du script
+#-----------+--------+-------------+------------------------------------------------------
+
+###############################################################################################
+
+. /root/.bash_profile
+
+# Configuration de base: datestamp e.g. YYYYMMDD
+DATE=$(date +"%Y%m%d")
+
+# Dossier où sauvegarder les backups
+BACKUP_DIR="/var/backup/GITLAB_RUNNER"
+
+# Commande NOMAD
+#NOMAD=/usr/local/bin/nomad
+NOMAD=$(which nomad)
+
+#Repo PATH To BACKUP DATA in the container
+REPO_PATH_CONF=/etc/gitlab-runner
+#Archive Name of the backup repo directory
+BACKUP_CONF_FILENAME="BACKUP_CONF_GITLAB_RUNNER_${DATE}.tar.gz"
+
+
+# Nombre de jours à garder les dossiers (seront effacés après X jours)
+RETENTION=3
+
+# ---- NE RIEN MODIFIER SOUS CETTE LIGNE ------------------------------------------
+#
+# Create a new directory into backup directory location for this date
+mkdir -p $BACKUP_DIR/$DATE
+
+#  Backup conf
+echo "Starting backup GITLAB_RUNNER conf..."
+
+$NOMAD exec -job -task gitlab-runner-java forge-gitlab-runner-java tar -cOzv -C $REPO_PATH_CONF/ . > $BACKUP_DIR/$DATE/$BACKUP_CONF_FILENAME
+BACKUP_RESULT=$?
+if [ $BACKUP_RESULT -gt 1 ]
+then
+        echo "Backup GITLAB_RUNNER conf failed with error code : ${BACKUP_RESULT}"
+        exit 1
+else
+        echo "Backup GITLAB_RUNNER conf"
+fi
+
+# Remove files older than X days
+find $BACKUP_DIR/* -mtime +$RETENTION -exec rm -rf {} \;
+
+echo "GITLAB_RUNNER finished"
+

--- a/gitlab-runner/waypoint.hcl
+++ b/gitlab-runner/waypoint.hcl
@@ -47,7 +47,7 @@ variable "image" {
 
 variable "tag" {
     type    = string
-    default = "latest"
+    default = "v15.10.1"
 }
 
 variable "external_url_gitlab_hostname" {

--- a/gitlab/waypoint.hcl
+++ b/gitlab/waypoint.hcl
@@ -50,7 +50,7 @@ variable "image" {
 
 variable "tag" {
     type    = string
-    default = "latest"
+    default = "15.10.2-ce.0"
 }
 
 variable "external_url_gitlab_hostname" {

--- a/gitlab_backup.sh
+++ b/gitlab_backup.sh
@@ -4,7 +4,7 @@ echo "Démarrage du script de sauvegarde de GitLab"
 # Nom du script     : gitlab-backup.sh
 # Auteur            : E.RIEGEL (QM HENIX)
 # Date de Création  : 22/02/2023
-# Version           : 0.0.1
+# Version           : 1.0.0
 # Descritpion       : Script permettant la sauvegarde des données de Gitlab
 #
 # Historique des mises à jour :


### PR DESCRIPTION
Cette PR afin de fixer le numéro de version de gitlab et de gitlab-runner directement dans les descripteurs de déploiement Waypoint. Cette PR embarque aussi l'ajout du script de sauvegarde gitlab-runne-java.